### PR TITLE
Updated Primary btn to use a cleaner sr-only label

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -64,7 +64,8 @@ const Element = href ? 'a' : 'button'
       {...attrs}
     >
       {variant === 'primary' ? (
-        <span class="btn__letters">{label}</span>
+        <span class="sr-only">{label}</span>
+        <span class="btn__letters" aria-hidden="true">{label}</span>
       ) : (
         <>
           {label}


### PR DESCRIPTION
## About
Small little fix that ensures consistent aria behavior between various screen readers. In order to prevent individual letters possibly getting read off with some screen readers, I now `aria-hidden` the letters and provide a clean `sr-only` label in its place.