### PR TITLE
Various QA Fixes

### DIFF
--- a/src/components/case-studies/CaseStudy.astro
+++ b/src/components/case-studies/CaseStudy.astro
@@ -95,11 +95,11 @@ const { data, mediaAspectRatio, class: className, id, ...attrs } = Astro.props
     @apply relative -order-1 mx-auto flex w-[calc(100%-32px)] items-center;
 
     @screen sm {
-      @apply -mt-32;
+      /* @apply -mt-32; */
     }
 
     @screen md {
-      @apply order-none -my-96 w-full min-w-[650px] max-w-[800px];
+      @apply order-none  w-full min-w-[650px] max-w-[800px];
     }
 
     & :global(> *) {

--- a/src/components/case-studies/CaseStudy.astro
+++ b/src/components/case-studies/CaseStudy.astro
@@ -94,10 +94,6 @@ const { data, mediaAspectRatio, class: className, id, ...attrs } = Astro.props
   .case__media {
     @apply relative -order-1 mx-auto flex w-[calc(100%-32px)] items-center;
 
-    @screen sm {
-      /* @apply -mt-32; */
-    }
-
     @screen md {
       @apply order-none  w-full min-w-[650px] max-w-[800px];
     }

--- a/src/components/case-studies/clients/AppOmni.astro
+++ b/src/components/case-studies/clients/AppOmni.astro
@@ -65,7 +65,7 @@ const entry = await getEntry('case-studies', 'app-omni')
       0px 27px 14px -2px rgba(57, 34, 0, 0.02);
 
     @screen md {
-      @apply left-[-16%] top-[7.5%] -mr-112 motion-reduce:top-0;
+      @apply left-[-16%] top-[8.5%] -mr-112 motion-reduce:top-0;
     }
 
     @screen lg {

--- a/src/components/case-studies/clients/GrubMarket.astro
+++ b/src/components/case-studies/clients/GrubMarket.astro
@@ -94,7 +94,7 @@ const entry = await getEntry('case-studies', 'grub-market')
       0px 2px 6px rgba(0, 0, 0, 0.08);
 
     @screen md {
-      @apply top-[-17.7%];
+      @apply top-[-23%];
     }
   }
 
@@ -107,12 +107,12 @@ const entry = await getEntry('case-studies', 'grub-market')
       -6px -12px 16px 0px rgba(141, 88, 2, 0.06);
 
     @screen md {
-      @apply top-[-32.5%];
+      @apply top-[-50%];
     }
   }
 
   [data-grub-asset='row-highlight'] {
-    @apply relative left-[-7%] top-[-4%] w-[67%] rounded-[0.5vmin];
+    @apply relative left-[-7%] top-[-2%] w-[67%] rounded-[0.5vmin] motion-reduce:top-[-4%];
 
     box-shadow:
       0px 10px 20px 0px rgba(136, 116, 84, 0.32),
@@ -120,21 +120,21 @@ const entry = await getEntry('case-studies', 'grub-market')
   }
 
   [data-grub-asset='graph'] {
-    @apply relative left-[-25%] top-[5%] w-[22%] rounded-[1vmin];
+    @apply relative left-[-25%] top-[7%] w-[22%] rounded-[1vmin] motion-reduce:top-[30%];
 
     box-shadow:
       0px 6px 16px 0px rgba(105, 86, 55, 0.12),
       0px 2px 6px -2px rgba(0, 0, 0, 0.08);
 
     @screen md {
-      @apply top-[16%];
+      @apply top-[20%];
     }
   }
 
   [data-grub-asset='tag'] {
     --tag-top: 65%;
-    --tag-height: 4.5%;
-    --tag-gap: 0.75%;
+    --tag-height: 6%;
+    --tag-gap: 1%;
 
     @apply absolute left-[72%] w-auto rounded-[1vmin];
 

--- a/src/components/case-studies/clients/SpectrumAI.astro
+++ b/src/components/case-studies/clients/SpectrumAI.astro
@@ -31,7 +31,7 @@ const entry = await getEntry('case-studies', 'spectrum-ai')
     <Image
       src={brainAsset}
       alt=""
-      class="translate-y-[-5%] sm:translate-y-0 md:w-4/5 <md:w-4/5"
+      class="w-4/5 translate-y-[-5%] sm:translate-y-0 sm:scale-110"
     />
   </div>
   <div data-speed="1.01">
@@ -98,14 +98,14 @@ const entry = await getEntry('case-studies', 'spectrum-ai')
   }
 
   [data-spectrum-asset='controls'] {
-    @apply relative left-[-16%] top-[-16%] w-[20%];
+    @apply relative left-[-16%] top-[-23%] w-[20%] motion-reduce:top-[-30%];
 
     filter: drop-shadow(0px 12px 40px rgba(0, 102, 182, 0.24))
       drop-shadow(0px 4px 6px rgba(0, 0, 0, 0.08));
   }
 
   [data-spectrum-asset='behavior'] {
-    @apply relative left-[-28%] top-[-10%] w-[25%];
+    @apply relative left-[-28%] top-[-10%] w-[25%] motion-reduce:top-[-2%];
 
     box-shadow:
       0px 6px 16px 0px rgba(0, 102, 182, 0.12),
@@ -117,14 +117,14 @@ const entry = await getEntry('case-studies', 'spectrum-ai')
   }
 
   [data-spectrum-asset='segmented-control'] {
-    @apply relative left-[-13%] top-[16%] w-[35%];
+    @apply relative left-[-13%] top-[22%] w-[35%];
 
     box-shadow: var(--spectrum-shadow-1);
   }
 
   [data-spectrum-asset='tracker'] {
-    --tracker-top: 42%;
-    --tracker-height: 6%;
+    --tracker-top: 45%;
+    --tracker-height: 8%;
     --tracker-gap: 1%;
 
     @apply absolute left-[70%] w-auto rounded-[0.25vmin];

--- a/src/components/case-studies/clients/SpectrumAI.astro
+++ b/src/components/case-studies/clients/SpectrumAI.astro
@@ -31,7 +31,7 @@ const entry = await getEntry('case-studies', 'spectrum-ai')
     <Image
       src={brainAsset}
       alt=""
-      class="translate-y-[-10%] md:translate-y-[-5%] <md:w-4/5"
+      class="translate-y-[-5%] sm:translate-y-0 md:w-4/5 <md:w-4/5"
     />
   </div>
   <div data-speed="1.01">
@@ -155,6 +155,12 @@ const entry = await getEntry('case-studies', 'spectrum-ai')
         var(--tracker-top) + (var(--tracker-height) * 3) +
           (var(--tracker-gap) * 3)
       );
+    }
+  }
+
+  [data-spectrum-asset] {
+    @screen md-lg {
+      transform: translateX(-100px);
     }
   }
 </style>

--- a/src/components/case-studies/clients/SpectrumAI.astro
+++ b/src/components/case-studies/clients/SpectrumAI.astro
@@ -160,7 +160,7 @@ const entry = await getEntry('case-studies', 'spectrum-ai')
 
   [data-spectrum-asset] {
     @screen md-lg {
-      transform: translateX(-100px);
+      @apply -translate-x-64;
     }
   }
 </style>

--- a/src/components/case-studies/clients/StandardAI.astro
+++ b/src/components/case-studies/clients/StandardAI.astro
@@ -94,7 +94,7 @@ const entry = await getEntry('case-studies', 'standard-ai')
   }
 
   [data-standard-ai-asset='stockphoto'] {
-    @apply relative left-[-30%] top-[10%] w-[40%] rounded-[1vmin];
+    @apply relative left-[-30%] top-[16.5%] w-[35%] rounded-[1vmin];
 
     box-shadow: var(--standard-ai-shadow);
 
@@ -107,7 +107,7 @@ const entry = await getEntry('case-studies', 'standard-ai')
     @apply relative left-[34%] top-[25%] w-[40%];
 
     @screen lg {
-      @apply left-[32%] top-[16%] w-[35%];
+      @apply left-[32%] top-[20%] w-[35%];
     }
 
     @screen md-lg {
@@ -124,8 +124,8 @@ const entry = await getEntry('case-studies', 'standard-ai')
   }
 
   [data-standard-ai-asset='card'] {
-    --card-top: -22.5%;
-    --card-height: 17.5%;
+    --card-top: -32.5%;
+    --card-height: 19%;
     --card-gap: -10%;
 
     @apply absolute left-[59%] w-auto origin-bottom-left rounded-[1vmin] motion-reduce:[--card-top:5%];
@@ -137,12 +137,16 @@ const entry = await getEntry('case-studies', 'standard-ai')
       0px 4px 6px -2px rgba(0, 0, 0, 0.08);
     transform: rotate(-36deg);
 
+    @screen xs {
+      @apply [--card-top:-20%] motion-reduce:[--card-top:10%];
+    }
+
     @screen sm {
-      @apply [--card-top:-15%] motion-reduce:[--card-top:10%];
+      @apply [--card-top:-12.5%] motion-reduce:[--card-top:10%];
     }
 
     @screen md {
-      @apply [--card-height:15%] [--card-top:10%] motion-reduce:[--card-top:20%];
+      @apply [--card-height:15%] [--card-top:-5%] motion-reduce:[--card-top:6%];
     }
 
     @screen md-lg {

--- a/src/components/case-studies/clients/StandardAI.astro
+++ b/src/components/case-studies/clients/StandardAI.astro
@@ -107,7 +107,7 @@ const entry = await getEntry('case-studies', 'standard-ai')
     @apply relative left-[34%] top-[25%] w-[40%];
 
     @screen lg {
-      @apply left-[32%] top-[20%] w-[35%];
+      @apply left-[32%] top-[23%] w-[35%];
     }
 
     @screen md-lg {

--- a/src/components/design-and-develop/Section.astro
+++ b/src/components/design-and-develop/Section.astro
@@ -51,7 +51,7 @@ const entry = await getEntry('sections', 'design-and-develop')
             data-animate-duration="1"
           />
           <figcaption class="sr-only">
-            A screenshot of the Spectrum AI in-session dashboard with the
+            Screenshots of the Spectrum AI in-session dashboard with the
             sidebar open displaying a live video feed.
           </figcaption>
         </figure>

--- a/src/components/design-and-develop/Section.astro
+++ b/src/components/design-and-develop/Section.astro
@@ -35,7 +35,7 @@ const entry = await getEntry('sections', 'design-and-develop')
             hueStop={210}
           />
         </div>
-        <div class="relative aspect-[650/406] w-full">
+        <figure class="relative aspect-[650/406] w-full">
           <Image
             src={dashboardAsset}
             alt=""
@@ -50,7 +50,11 @@ const entry = await getEntry('sections', 'design-and-develop')
             data-animate="up"
             data-animate-duration="1"
           />
-        </div>
+          <figcaption class="sr-only">
+            A screenshot of the Spectrum AI in-session dashboard with the
+            sidebar open displaying a live video feed.
+          </figcaption>
+        </figure>
       </div>
       <List details={entry.data.right} data-animate="right" />
     </div>

--- a/src/components/testimonials/Section.astro
+++ b/src/components/testimonials/Section.astro
@@ -32,7 +32,19 @@ const sortedTestiomonals = allTestimonials.sort((a, b) => {
   <Button
     label={entry.data.cta.label}
     href={entry.data.cta.url}
+    class="<xs:!hidden"
     size="lg"
     data-animate="up"
   />
+  {
+    entry.data.cta.shortLabel && (
+      <Button
+        label={entry.data.cta.shortLabel}
+        href={entry.data.cta.url}
+        class="xs:!hidden"
+        size="lg"
+        data-animate="up"
+      />
+    )
+  }
 </section>

--- a/src/content/sections/testimonials.md
+++ b/src/content/sections/testimonials.md
@@ -19,5 +19,6 @@ marquee:
     logo: '@/assets/images/testimonials/logos/unknown-logo-3.png'
 cta:
   label: See Who Else We’re Working With
+  shortLabel: See Our Clients
   url: 'https://www.viget.com/clients/'
 ---

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -9,11 +9,13 @@ export default {
   content: ['./src/**/*.{astro,html,svg,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
     screens: {
+      xs: '400px',
       sm: '550px',
       md: '768px',
       lg: '1024px',
       xl: '1440px',
       'md-lg': { min: '768px', max: '1023.98px' },
+      '<xs': { max: '399.98px' },
       '<sm': { max: '549.98px' },
       '<md': { max: '767.98px' },
       '<lg': { max: '1023.98px' },

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -9,13 +9,13 @@ export default {
   content: ['./src/**/*.{astro,html,svg,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
     screens: {
-      xs: '400px',
+      xs: '420px',
       sm: '550px',
       md: '768px',
       lg: '1024px',
       xl: '1440px',
       'md-lg': { min: '768px', max: '1023.98px' },
-      '<xs': { max: '399.98px' },
+      '<xs': { max: '419.98px' },
       '<sm': { max: '549.98px' },
       '<md': { max: '767.98px' },
       '<lg': { max: '1023.98px' },


### PR DESCRIPTION
## About
This PR resolves various QA issues addressed in [this notion page](https://www.notion.so/viget/Viget-Startups-QA-d72774720b564e12bbfc90fd8f36263d?d=9420cacffd714f9dbbf1f04c75453140).

## Specific Changes
- [x] Add sr-only `figcaption` for Design and Development section
- [x] Adjust Spectrum AI Case Study asset position to be closer to text for Tablet display
  | BEFORE | AFTER |
  |--------|--------|
  | ![image](https://github.com/vigetlabs/viget-startups/assets/8878152/0e7f5ea5-231c-46ac-a77e-b437f4ee2816) | ![image](https://github.com/vigetlabs/viget-startups/assets/8878152/86e4a968-1400-4004-955f-6c96defd9444) | 

- [x] Create a shortform mobile CTA for testimonial block
  | BEFORE | AFTER |
  |--------|--------|
  | ![image](https://github.com/vigetlabs/viget-startups/assets/8878152/ed267d83-40b4-4364-8b9f-1c93e3f1fb87) | ![image](https://github.com/vigetlabs/viget-startups/assets/8878152/4aef98a8-2106-4598-997f-bf6ded4fad6f) | 

- [x] Various positioning and Case Study Asset sizing improvements to resolve Safari inconsistencies.
  | BEFORE | AFTER |
  |--------|--------|
  | ![Untitled](https://github.com/vigetlabs/viget-startups/assets/8878152/93839e41-6d88-4c1c-b262-8aef59c63798) | ![image](https://github.com/vigetlabs/viget-startups/assets/8878152/e3c25668-802e-4cb4-bf03-98db2e28c2c1) | 

## Testing
All changes can be viewed and tested on the [Staging site](https://staging.startups.viget.com/).

- [ ] Validate that the **Design & Development** image has a working `sr-only` label.
- [ ] Validate that the spacing for the **Spectrum AI** case study between content and assets is consistent with the rest of the case studies.
- [ ] Validate that there is a shortform CTA for the **What our clients say** section on small devices (sub `400px`)
- [ ] Validate that assets are sized consistently between Safari and Chromium browsers.
